### PR TITLE
Refactors backend registration and CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,13 +2,12 @@ name: CI
 on:
   push:
     branches:
-      - main
       - dev
     tags: ['*']
   pull_request:
     branches:
       - main
-      - dev
+      
   workflow_dispatch:
 
 concurrency:

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -66,19 +66,26 @@ try
     using CUDA
     @info "🧠 CUDA 🔁 overloading stub functions..."
     include(joinpath(@__DIR__, "CUDAExt", "CUDA_backend.jl"))
-    add_backend!(Val(:CUDA), backend())
 catch e
     @warn """
     ⚠️ CUDA extension failed to load.
     
     To enable CUDA support:
       1. Install CUDA.jl in your base environment:
-         ] activate
-         ] add CUDA
-      2. Restart Julia and load UnifiedBackend
+        using Pkg
+        Pkg.activate()  # Activate your base environment
+        Pkg.add("CUDA")
+      2. Restart Julia, and:
+        using UnifiedBackend
+        using CUDA  # Triggers automatic loading of CUDAExt
     
     Error: $e
     """
+end
+
+function __init__()
+    add_backend!(Val(:CUDA), backend())
+    @info "✅ CUDA backend registered successfully"
 end
 
 end

--- a/ext/CUDAExt/CUDA_backend.jl
+++ b/ext/CUDAExt/CUDA_backend.jl
@@ -23,14 +23,14 @@ function add_backend!(::Val{:CUDA}, bckd::Backend)
         if backend[:functional]
             for (k, device) ∈ enumerate(backend[:devices]())
                 dev_id += 1
-                bckd.exec.device[Symbol("dev$(dev_id)")] = (; 
-                    dev      = backend[:dev],
-                    platform = platform,
-                    brand    = backend[:brand],
-                    name     = backend[:name](device),
-                    Backend  = backend[:Backend],
-                    wrapper  = backend[:wrapper],
-                    handle   = device,
+                bckd.exec.device[Symbol("dev$(dev_id)")] = Dict(
+                    :host     => "gpu",   
+                    :platform => platform,        
+                    :brand    => backend[:brand],            
+                    :name     => backend[:name](device),
+                    :Backend  => backend[:Backend],
+                    :wrapper  => backend[:wrapper],
+                    :handle   => device,
                 )
             end
             push!(bckd.exec.functional, "✓ $(backend[:brand]) $(platform)")
@@ -63,6 +63,7 @@ Description:
 ---
 Return Dicts of effective cpu and gpu backend based on hard-coded supported backends. 
 """
+#=
 function device_free!(mesh::Mesh,::Val{:CUDA})
     msg = ["freed GPU memory (VRAM):\n"]
     for i in 1:nfields(mesh)
@@ -77,3 +78,4 @@ function device_free!(mesh::Mesh,::Val{:CUDA})
     GC.gc()
     return nothing
 end
+=#

--- a/ext/ROCmExt.jl
+++ b/ext/ROCmExt.jl
@@ -56,7 +56,7 @@ end
 """
 module ROCmExt
 
-@info "📦 Including ROCmExt.jl extension module"
+@info "📦 Including extension module"
 
 using UnifiedBackend
 import UnifiedBackend: add_backend!
@@ -66,20 +66,27 @@ try
     using AMDGPU
     @info "🧠 ROCm 🔁 overloading stub functions..."
     include(joinpath(@__DIR__, "ROCmExt", "ROCm_backend.jl"))
-    add_backend!(Val(:ROCm), backend())
 catch e
     @warn """
     ⚠️ ROCm extension failed to load.
     
     To enable ROCm support:
       1. Install AMDGPU.jl in your base environment:
-         ] activate
-         ] add AMDGPU
+        using Pkg
+        Pkg.activate()  # Activate your base environment
+        Pkg.add("AMDGPU")
       2. Ensure ROCm runtime is installed on your system
-      3. Restart Julia and load UnifiedBackend
-    
+      3. Restart Julia, and:
+        using UnifiedBackend
+        using AMDGPU  # Triggers automatic loading of ROCmExt
+
     Error: $e
     """
+end
+
+function __init__()
+    add_backend!(Val(:ROCm), backend())
+    @info "✅ ROCm backend registered successfully"
 end
 
 end

--- a/ext/ROCmExt/ROCm_backend.jl
+++ b/ext/ROCmExt/ROCm_backend.jl
@@ -23,14 +23,14 @@ function add_backend!(::Val{:ROCm}, bckd::Backend)
         if backend[:functional]
             for (k, device) ∈ enumerate(backend[:devices]())
                 dev_id += 1
-                bckd.exec.device[Symbol("dev$(dev_id)")] = (; 
-                    dev      = backend[:dev],
-                    platform = platform,
-                    brand    = backend[:brand],
-                    name     = backend[:name](device),
-                    Backend  = backend[:Backend],
-                    wrapper  = backend[:wrapper],
-                    handle   = device,
+                bckd.exec.device[Symbol("dev$(dev_id)")] = Dict(
+                    :host     => "gpu",   
+                    :platform => platform,        
+                    :brand    => backend[:brand],            
+                    :name     => backend[:name](device),
+                    :Backend  => backend[:Backend],
+                    :wrapper  => backend[:wrapper],
+                    :handle   => device,
                 )
             end
             push!(bckd.exec.functional, "✓ $(backend[:brand]) $(platform)")


### PR DESCRIPTION
Updates backend registration to use `__init__` for automatic loading and simplifies the CI workflow.

- Refactors the CUDA backend registration process to leverage the `__init__` function, ensuring automatic backend loading upon module import.
- Provides more explicit instructions for enabling CUDA support, improving user guidance.
- Standardizes device information storage to use a `Dict` and adds `host` type information.
- Simplifies the ROCmExt module inclusion info message for better clarity.
- Modifies the CI workflow to trigger on pushes to the `dev` branch.