### PR TITLE
Refactors backend API for clarity

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,7 +10,9 @@ CollapsedDocStrings = true
 ### Backend Access
 
 ```@docs
-backend
+get_backend
+Host
+Device
 Backend
 ExecutionPlatforms
 ```

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -25,7 +25,7 @@ Pkg.add("CUDA")
 using UnifiedBackend
 using CUDA  # Automatically loads CUDAExt
 
-b = backend()
+b = get_backend()
 
 # Check for CUDA devices
 if !isempty(b.exec.device)
@@ -67,7 +67,7 @@ Pkg.add("AMDGPU")
 using UnifiedBackend
 using AMDGPU  # Automatically loads ROCmExt
 
-b = backend()
+b = get_backend()
 
 # Check for ROCm devices
 if !isempty(b.exec.device)
@@ -98,7 +98,7 @@ When requesting GPU execution without GPU extensions loaded, UnifiedBackend auto
 
 ```julia
 # No GPU package loaded
-gpu = select_execution_backend(backend().exec, "device")
+gpu = select_execution_backend(get_backend().exec, "device")
 # Info: No GPU available, falling back to CPU backend
 # Returns CPU device instead
 ```
@@ -137,7 +137,7 @@ AMDGPU.versioninfo()  # Check ROCm installation
 3. **Extension loading**:
 ```julia
 using UnifiedBackend
-backend()  # Check exec.functional for loaded backends
+get_backend()  # Check exec.functional for loaded backends
 ```
 
 Warnings during extension loading are captured and displayed with troubleshooting hints.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,7 @@ UnifiedBackend provides a consistent interface for managing and executing code a
 using UnifiedBackend
 
 # Access backend
-b = backend()
+b = get_backend()
 
 # Use CPU
 cpu = select_execution_backend(b.exec, "host")

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -27,7 +27,7 @@ Pkg.add("CUDA")
 using UnifiedBackend
 using CUDA  # Triggers automatic loading of CUDAExt
 
-b = backend()
+b = get_backend()
 
 # Check if CUDA devices were registered
 if !isempty(b.exec.device)

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -67,6 +67,7 @@ try
     @info "🧠 CUDA 🔁 overloading stub functions..."
     include(joinpath(@__DIR__, "CUDAExt", "CUDA_backend.jl"))
     global cuda_success = true
+    global cuda_functional = CUDA.functional()
 catch e
     @warn """
     ⚠️ CUDA extension failed to load.
@@ -86,9 +87,12 @@ catch e
 end
 
 function __init__()
-    if cuda_success
+    if cuda_success && cuda_functional
+        @info "✅ CUDA extension loaded successfully. Registering CUDA backend..."
         add_backend!(Val(:CUDA), get_backend())
-        @info "✅ CUDA backend registered successfully"
+        return nothing
+    elseif cuda_success && !cuda_functional
+        @info "🟡 CUDA extension loaded successfully but CUDA is not functional on this system."
         return nothing
     else
         @info "❌ CUDA backend registration failed"

--- a/ext/ROCmExt.jl
+++ b/ext/ROCmExt.jl
@@ -67,6 +67,7 @@ try
     @info "🧠 ROCm 🔁 overloading stub functions..."
     include(joinpath(@__DIR__, "ROCmExt", "ROCm_backend.jl"))
     global rocm_success = true
+    global rocm_functional = AMDGPU.functional()
 catch e
     @warn """
     ⚠️ ROCm extension failed to load.
@@ -87,9 +88,12 @@ catch e
 end
 
 function __init__()
-    if rocm_success
+    if rocm_success && rocm_functional
         add_backend!(Val(:ROCm), get_backend())
         return @info "✅ ROCm backend registered successfully"
+    elseif rocm_success && !rocm_functional
+        @info "🟡 ROCm extension loaded successfully but ROCm is not functional on this system."
+        return nothing
     else
         return @info "❌ ROCm backend registration failed"
     end

--- a/ext/ROCmExt.jl
+++ b/ext/ROCmExt.jl
@@ -27,7 +27,7 @@ Pkg.add("AMDGPU")
 using UnifiedBackend
 using AMDGPU  # Triggers automatic loading of ROCmExt
 
-b = backend()
+b = get_backend()
 
 # Check if ROCm devices were registered
 if !isempty(b.exec.device)
@@ -37,10 +37,10 @@ if !isempty(b.exec.device)
     gpu = select_execution_backend(b.exec, "device")
     
     # Access ROCm-specific properties
-    println(gpu.dev1[:name])      # "AMD Radeon RX 6900 XT"
-    println(gpu.dev1[:Backend])   # ROCBackend()
-    println(gpu.dev1[:wrapper])   # ROCArray
-    println(gpu.dev1[:handle])    # HIPDevice(0)
+    println(gpu[:dev1].name)      # "AMD Radeon RX 6900 XT"
+    println(gpu[:dev1].Backend)   # ROCBackend()
+    println(gpu[:dev1].wrapper)   # ROCArray
+    println(gpu[:dev1].handle)    # HIPDevice(0)
 end
 ```
 

--- a/src/UnifiedBackend.jl
+++ b/src/UnifiedBackend.jl
@@ -83,9 +83,6 @@ using Revise, Pkg, Test
 using ProgressMeter, REPL.TerminalMenus
 
 using KernelAbstractions, Adapt, Base.Threads
-import KernelAbstractions.@atomic as @atom
-import KernelAbstractions.Kernel as Cairn
-import KernelAbstractions.synchronize as sync
 
 # Include types
 include(joinpath(SRC, "boot/include.jl"))

--- a/src/boot/needs/types/concrete/types.jl
+++ b/src/boot/needs/types/concrete/types.jl
@@ -151,7 +151,7 @@ The `Backend` struct uses an immutable wrapper around mutable data pattern:
 using UnifiedBackend
 
 # Access the global backend instance
-b = backend()
+b = get_backend()
 
 # Inspect library registry (populated by module loading system)
 println(keys(b.lib))
@@ -174,17 +174,17 @@ cpus = b.exec.host
 
 # Global Instance
 
-UnifiedBackend maintains a global singleton instance accessed via [`backend()`](@ref):
+UnifiedBackend maintains a global singleton instance accessed via [`get_backend()`](@ref):
 
 ```julia
-b = backend()
+b = get_backend()
 devices = select_execution_backend(b.exec, "host")
 ```
 
 # See Also
 
 - [`ExecutionPlatforms`](@ref): Execution platform registry structure
-- [`backend`](@ref): Accessor for the global `Backend` instance
+- [`get_backend`](@ref): Accessor for the global `Backend` instance
 - [`select_execution_backend`](@ref): Device selection function
 """
 Base.@kwdef struct Backend

--- a/src/home/api/backend_setup.jl
+++ b/src/home/api/backend_setup.jl
@@ -3,32 +3,30 @@ export add_backend!
 """
     list_host_backend() -> Dict{Symbol, Dict{Symbol, Any}}
 
-Return a dictionary of supported host (CPU) backend configurations.
+Return a dictionary of supported host (CPU) backend configurations for each architecture.
 
-This function provides the hardcoded specifications for supported CPU architectures,
-including their KernelAbstractions backend, supported brands, and functional status
-based on the current system architecture.
-
-# Returns
-
-Dictionary mapping architecture symbols to configuration dictionaries:
-- `:x86_64`: Intel and AMD x86-64 processors
-- `:aarch64`: ARM64 processors (Apple Silicon, ARM servers)
-
-Each configuration contains:
+Each architecture entry (e.g., `:x86_64`, `:aarch64`) contains:
 - `:host`: Device category ("cpu")
 - `:Backend`: KernelAbstractions CPU backend instance
 - `:brand`: Array of supported manufacturer strings
 - `:wrapper`: Array type for computations
-- `:functional`: Boolean indicating if this architecture matches current system
+- `:devices`: Placeholder for device list (usually `nothing`)
+- `:name`: Placeholder for device name (usually `nothing`)
+- `:handle`: Type handle (e.g., `Val{:Host}`)
+- `:functional`: Boolean indicating if this architecture matches the current system
+
+# Returns
+
+Dictionary mapping architecture symbols to configuration dictionaries.
 
 # Examples
 
 ```julia
 backends = list_host_backend()
 x86_config = backends[:x86_64]
-println(x86_config[:brand])  # ["Intel(R)", "AMD"]
-println(x86_config[:functional])  # true (on x86-64 systems)
+println(x86_config[:brand])      # ["Intel(R)", "AMD"]
+println(x86_config[:functional]) # true (on x86-64 systems)
+println(x86_config[:devices])    # nothing
 ```
 """
 function list_host_backend()
@@ -119,27 +117,6 @@ Each registered device receives:
 - `:Backend`: KernelAbstractions `CPU()` backend
 - `:wrapper`: `Array` type for computations
 - `:handle`: `nothing` (CPUs don't require device handles)
-
-# Examples
-
-```julia
-using UnifiedBackend
-
-# Get the global backend
-b = backend()
-
-# Initialize for current architecture (usually automatic)
-add_backend!(b.exec, Val(Sys.ARCH))
-
-# Inspect registered devices
-for (dev_id, config) in b.exec.host
-    println("\$dev_id: \$(config[:name])")
-end
-# Output:
-# dev1: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
-# dev2: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
-# ... (one per logical core)
-```
 
 # Errors
 

--- a/src/home/api/device_management.jl
+++ b/src/home/api/device_management.jl
@@ -23,7 +23,7 @@ device_wakeup!()  # ErrorException
 
 # After loading CUDA
 using CUDA
-gpu = select_execution_backend(backend().exec, "device")
+gpu = select_execution_backend(get_backend().exec, "device")
 device_wakeup!(gpu.dev1[:handle])  # Sets active CUDA device
 ```
 


### PR DESCRIPTION
Renames `backend()` to `get_backend()` to improve clarity and consistency in accessing the global backend instance.

- Updates all instances of `backend()` to `get_backend()` across the codebase, including documentation, extensions, and core files.
- Improves CUDA and ROCm extension loading and logging, including checks for functionality before registering backends.
- Enhances ROCm backend registration with AMDGPU functionality checks, ensuring that the backend is functional before registration.